### PR TITLE
updated express version for example

### DIFF
--- a/example/server.js
+++ b/example/server.js
@@ -9,10 +9,11 @@ var jwt_secret = 'foo bar big secret';
 
 var app = express();
 
-app.configure(function(){
-  this.use(express.json());
-  this.use(express.static(__dirname + '/public'));
-});
+var serveStatic = require('serve-static')
+var bodyParser   = require('body-parser');
+
+app.use(serveStatic('public', {'index': ['index.html']}))
+app.use(bodyParser.json());
 
 app.post('/login', function (req, res) {
   var profile = {

--- a/package.json
+++ b/package.json
@@ -26,8 +26,9 @@
     "xtend": "~2.1.2"
   },
   "devDependencies": {
-    "connect": "~2.7.11",
-    "express": "~3.1.2",
+    "express": "~4.10.6",
+    "body-parser": "^1.10.0",
+    "serve-static": "^1.7.1",
     "mocha": "~1.17.0",
     "passport-local": "~0.1.6",
     "request": "~2.19.0",


### PR DESCRIPTION
updated the example to work with express version 4.10.6.
Removed connect middleware. Added serve-static and body-parser
middleware.
Updated package.json to reflect changes