### PR TITLE
Update jsonwebtoken to v5.0.0 in order to fix critical vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "jsonwebtoken": "~4.2.0",
+    "jsonwebtoken": "~5.0.0",
     "xtend": "~2.1.2"
   },
   "devDependencies": {


### PR DESCRIPTION
See https://auth0.com/blog/2015/03/31/critical-vulnerabilities-in-json-web-token-libraries/