### PR TITLE
Send back fail reason to client in noQsMethod case

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+.idea
 node_modules/*

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,7 +15,6 @@ function noQsMethod(options) {
     }
 
     var auth_timeout = setTimeout(function () {
-      socket.emit('error', new UnauthorizedError('request_expiration', 'Token wasn\'t received on time'));
       socket.disconnect('unauthorized');
     }, options.timeout || 5000);
 
@@ -23,8 +22,10 @@ function noQsMethod(options) {
       clearTimeout(auth_timeout);
       jwt.verify(data.token, options.secret, options, function(err, decoded) {
         if (err) {
-          socket.emit('error', new UnauthorizedError('invalid_token', err));
-          return socket.disconnect('unauthorized');
+          socket.emit('unauthorized', err, function() {
+            socket.disconnect('unauthorized');
+          });
+          return; // stop logic, socket will be close on next tick
         }
 
         socket.decoded_token = decoded;

--- a/lib/index.js
+++ b/lib/index.js
@@ -21,19 +21,39 @@ function noQsMethod(options) {
     socket.on('authenticate', function (data) {
       clearTimeout(auth_timeout);
       jwt.verify(data.token, options.secret, options, function(err, decoded) {
+        // error handler
+        var onError = function(err, code) {
+          if (err) {
+            code = code || 'unknown';
+            var error = new UnauthorizedError(code, {
+              message: (Object.prototype.toString.call(err) === '[object Object]' && err.message) ? err.message : err
+            });
+            socket.emit('unauthorized', error, function() {
+              socket.disconnect('unauthorized');
+            });
+            return; // stop logic, socket will be close on next tick
+          }
+        };
+
         if (err) {
-          socket.emit('unauthorized', err, function() {
-            socket.disconnect('unauthorized');
-          });
-          return; // stop logic, socket will be close on next tick
+          return onError(err, 'invalid_token');
         }
 
-        socket.decoded_token = decoded;
-        socket.emit('authenticated');
-        if (server.$emit) {
-          server.$emit('authenticated', socket);
+        // success handler
+        var onSuccess = function(){
+          socket.decoded_token = decoded;
+          socket.emit('authenticated');
+          if (server.$emit) {
+            server.$emit('authenticated', socket);
+          } else {
+            server.server.sockets.emit('authenticated', socket);
+          }
+        };
+
+        if(options.additional && typeof options.additional === 'function') {
+          options.additional(decoded, onSuccess, onError);
         } else {
-          server.server.sockets.emit('authenticated', socket);
+          onSuccess();
         }
       });
     });

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,6 +15,7 @@ function noQsMethod(options) {
     }
 
     var auth_timeout = setTimeout(function () {
+      socket.emit('error', new UnauthorizedError('request_expiration', 'Token wasn\'t received on time'));
       socket.disconnect('unauthorized');
     }, options.timeout || 5000);
 
@@ -22,6 +23,7 @@ function noQsMethod(options) {
       clearTimeout(auth_timeout);
       jwt.verify(data.token, options.secret, options, function(err, decoded) {
         if (err) {
+          socket.emit('error', new UnauthorizedError('invalid_token', err));
           return socket.disconnect('unauthorized');
         }
 


### PR DESCRIPTION
Send error detail to client (token invalid, expired, ...) on autorisation fail when using the "second roundtrip" scenario.

May solves few related issues and requests.