### PR TITLE
fix(lib/index.js) return auth.success

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -144,7 +144,7 @@ function authorize(options, onConnection) {
 
       data.decoded_token = decoded;
 
-      auth.success(data, accept);
+      return auth.success(data, accept);
     });
   };
 }


### PR DESCRIPTION
Next step would not execute because no function(socket, next) was returned in case of successful verification in the 'one roundtrip' (handshake) approach.
Returning auth.success instead of just executing it solves this.

Fixes #51