### PR TITLE
Make .disconnect() async call optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,71 @@ socket.on("error", function(error) {
   }
 });
 ```
+
+## Handling invalid token
+
+Token sent by client is invalid.
+
+__Server side__:
+
+No further configuration needed.
+
+__Client side__:
+
+Add a callback client-side to execute socket disconnect server-side.
+
+```javascript
+socket.on("unauthorized", function(error, callback) {
+  if (error.data.type == "UnauthorizedError" || error.data.code == "invalid_token") {
+    // redirect user to login page perhaps or execute callback:
+    callback();
+    console.log("User's token has expired");
+  }
+});
+```
+
+__Server side__:
+
+To disconnect socket server-side without client-side callback:
+
+```javascript
+io.sockets.on('connection', socketioJwt.authorize({
+  secret: 'secret goes here',
+  // No client-side callback, terminate connection server-side
+  callback: false 
+}))
+```
+
+__Client side__:
+
+Nothing needs to be changed client-side if callback is false.
+
+__Server side__:
+
+To disconnect socket server-side while giving client-side 15 seconds to execute callback:
+
+```javascript
+io.sockets.on('connection', socketioJwt.authorize({
+  secret: 'secret goes here',
+  // Delay server-side socket disconnect to wait for client-side callback
+  callback: 15000 
+}))
+```
+
+Your client-side code should handle it as below.
+
+__Client side__:
+
+```javascript
+socket.on("unauthorized", function(error, callback) {
+  if (error.data.type == "UnauthorizedError" || error.data.code == "invalid_token") {
+    // redirect user to login page perhaps or execute callback:
+    callback();
+    console.log("User's token has expired");
+  }
+});
+```
+
 ## Getting the secret dynamically
 You can pass a function instead of an string when configuring secret.
 This function receives the request, the decoded token and a callback. This

--- a/lib/index.js
+++ b/lib/index.js
@@ -34,7 +34,23 @@ function noQsMethod(options) {
             var error = new UnauthorizedError(code, {
               message: (Object.prototype.toString.call(err) === '[object Object]' && err.message) ? err.message : err
             });
+            var callback_timeout;
+            // If callback explicitely set to false, start timeout to disconnect socket 
+            if (options.callback === false || typeof options.callback === "number") {
+              if (typeof options.callback === "number") {
+                if (options.callback < 0) {
+                  // If callback is negative(invalid value), make it positive
+                  options.callback = Math.abs(options.callback);
+                }
+              }
+              callback_timeout = setTimeout(function () {
+                socket.disconnect('unauthorized');
+              }, (options.callback === false ? 0 : options.callback));
+            }
             socket.emit('unauthorized', error, function() {
+              if (typeof options.callback === "number") {
+                clearTimeout(callback_timeout);
+              }
               socket.disconnect('unauthorized');
             });
             return; // stop logic, socket will be close on next tick


### PR DESCRIPTION
As of #42 socket disconnection is handled client-side, via a callback passed to the listener for the unauthorized event.  This is not optimal, at least for us, where we want to secure our socket server against outside unauthorized use.  While messages can't be sent, the connection remains open, and we can't just trust outside sources to give up trying after the first failed attempt.

This pull-request adds in an option called `callback`, whose default is `true`.  If `false` or a number is supplied, the socket disconnection is then mostly handled server side.  If it is `false`, on error, the socket is disconnected server-side.  If it is a number(which is validated to be positive via `Math.abs()`), the number is treated as a delay in milliseconds before the server disconnects the socket.  If a callback is supplied client-side, and executed, this callback clears the timeout that the delay is based on.