### PR TITLE
Use process.env.PORT when available

### DIFF
--- a/example/socketsio-auth0-sample/index.js
+++ b/example/socketsio-auth0-sample/index.js
@@ -11,6 +11,7 @@ var env = {
   AUTH0_CLIENT_ID: process.env.AUTH0_CLIENT_ID,
   AUTH0_DOMAIN: process.env.AUTH0_DOMAIN,
 }
+var port = process.env.PORT || 3001;
 
 app.set('views', __dirname + '/views')
 app.set('view engine', 'jade');
@@ -37,7 +38,7 @@ app.get('/', function (req, res) {
   )
 })	
 
-http.listen(3001, function(){
-	console.log('listening on *:3001');
+http.listen(port, function(){
+	console.log('listening on *:' + port);
 });
 


### PR DESCRIPTION
Use process.env.PORT when available, otherwise default to 3001