### PR TITLE
fix TypeError when authenticate is sent with null

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -41,7 +41,7 @@ function noQsMethod(options) {
           }
       };
 
-      if(typeof data.token !== "string") {
+      if(!data || typeof data.token !== "string") {
         return onError({message: 'invalid token datatype'}, 'invalid_token');
       }
 


### PR DESCRIPTION
When 'authenticate' event is sent by client with null(by mistake or intentionally), TypeError occurs.