### PR TITLE
Added ability to use a custom decodedPropertyName

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -53,7 +53,7 @@ function noQsMethod(options) {
 
         // success handler
         var onSuccess = function() {
-          socket.decoded_token = decoded;
+          socket[options.decodedPropertyName] = decoded;
           socket.emit('authenticated');
           if (server.$emit) {
             server.$emit('authenticated', socket);
@@ -89,6 +89,8 @@ function noQsMethod(options) {
 }
 
 function authorize(options, onConnection) {
+  options = xtend({ decodedPropertyName: 'decoded_token' }, options);
+
   if (!options.handshake) {
     return noQsMethod(options);
   }
@@ -156,7 +158,7 @@ function authorize(options, onConnection) {
         return auth.fail(error, data, accept);
       }
 
-      data.decoded_token = decoded;
+      data[options.decodedPropertyName] = decoded;
 
       return auth.success(data, accept);
     };


### PR DESCRIPTION
This change would make it possible to use `socket.user` instead of `socket.decoded_token`.