### PR TITLE
Add encoded token to onSuccess() emit

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -69,6 +69,7 @@ function noQsMethod(options) {
 
         // success handler
         var onSuccess = function() {
+          socket[options.encodedPropertyName] = data.token;
           socket[options.decodedPropertyName] = decoded;
           socket.emit('authenticated');
           if (server.$emit) {
@@ -105,7 +106,10 @@ function noQsMethod(options) {
 }
 
 function authorize(options, onConnection) {
-  options = xtend({ decodedPropertyName: 'decoded_token' }, options);
+  options = xtend({
+    decodedPropertyName: 'decoded_token',
+    encodedPropertyName: 'encoded_token',
+  }, options);
 
   if (!options.handshake) {
     return noQsMethod(options);


### PR DESCRIPTION
To check if the encoded token was really generated by our server, we can store it (e.g. in a database) and perform a second step of validation. To do that, I added the encoded token (`data.token`) as a property to the `authenticated` event on the server side.