### PR TITLE
Added option to jwt.decode() to get the header

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -208,7 +208,7 @@ function getSecret(request, secret, token, callback) {
       return callback({ code: 'invalid_token', message: 'jwt signature is required' });
     }
 
-    var decodedToken = jwt.decode(token, complete = {complete: true});
+    var decodedToken = jwt.decode(token, {complete: true});
 
     if (!decodedToken) {
       return callback({ code: 'invalid_token', message: 'jwt malformed' });

--- a/lib/index.js
+++ b/lib/index.js
@@ -208,7 +208,7 @@ function getSecret(request, secret, token, callback) {
       return callback({ code: 'invalid_token', message: 'jwt signature is required' });
     }
 
-    var decodedToken = jwt.decode(token);
+    var decodedToken = jwt.decode(token, complete = {complete: true});
 
     if (!decodedToken) {
       return callback({ code: 'invalid_token', message: 'jwt malformed' });

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,6 +15,9 @@ function noQsMethod(options) {
       if (!~Namespace.events.indexOf('authenticated')) {
         Namespace.events.push('authenticated');
       }
+      if (!~Namespace.events.indexOf('unauthorized')) {
+          Namespace.events.push('unauthorized');
+      }
     }
 
     if(options.required){
@@ -53,6 +56,18 @@ function noQsMethod(options) {
               }
               socket.disconnect('unauthorized');
             });
+            if (server.$emit) {
+                  server.$emit('unauthorized', socket);
+            } else {
+                  //try getting the current namespace otherwise fallback to all sockets.
+                  var namespace = (server.nsps && socket.nsp &&
+                      server.nsps[socket.nsp.name]) ||
+                      server.sockets;
+
+                  // explicit namespace
+                  namespace.emit('unauthorized', socket);
+            }
+
             return; // stop logic, socket will be close on next tick
           }
       };

--- a/lib/index.js
+++ b/lib/index.js
@@ -22,6 +22,7 @@ function noQsMethod(options) {
 
     if(options.required){
       var auth_timeout = setTimeout(function () {
+        socket.emit('unauthorized');
         socket.disconnect('unauthorized');
         if (server.$emit) {
             server.$emit('unauthorized', socket);

--- a/lib/index.js
+++ b/lib/index.js
@@ -23,6 +23,16 @@ function noQsMethod(options) {
     if(options.required){
       var auth_timeout = setTimeout(function () {
         socket.disconnect('unauthorized');
+        if (server.$emit) {
+            server.$emit('unauthorized', socket);
+        } else {
+            //try getting the current namespace otherwise fallback to all sockets.
+            var namespace = (server.nsps && socket.nsp &&
+                server.nsps[socket.nsp.name]) ||
+                server.sockets;
+            // explicit namespace
+            namespace.emit('unauthorized', socket);
+        }
       }, options.timeout || 5000);
     }
 

--- a/test/fixture/secret_function.js
+++ b/test/fixture/secret_function.js
@@ -25,7 +25,7 @@ exports.start = function (options, callback) {
 
   options = xtend({
     secret: function(request, decodedToken, callback) {
-      callback(null, SECRETS[decodedToken.id]);
+      callback(null, SECRETS[decodedToken.payload.id]);
     },
     timeout: 1000,
     handshake: true


### PR DESCRIPTION
There are authentication protocols where information from the header of the JWT token must be used for extracting the secret/public key.